### PR TITLE
Cleanup tests

### DIFF
--- a/test/pymm_test.py
+++ b/test/pymm_test.py
@@ -2,10 +2,9 @@ from __future__ import print_function
 import sys
 # append parent directory so that import finds pymm
 sys.path.append('../')
-import unittest
-import warnings
 from uuid import uuid4
-import xml
+import unittest
+import inspect
 import os
 try:
     import pymm
@@ -17,10 +16,13 @@ except ImportError:
     print('please cd to test/ and rerun tests.py')
     raise
 
+# pylint: disable=R0904
+# pylint: disable=no-self-use
+
+
 # FAILING: richcontent does not handle itself correctly if html is not set
 # (usually if somebody just inits a richcontent node)
 # AKA: I have no idea if type variants are used at all in any mindmap
-
 class TestMutableClassVariables(unittest.TestCase):
     """ verify mutable variables are copied / deepcopied in instances. This
     ensures that class variables are not changed when changing an instance's
@@ -28,13 +30,18 @@ class TestMutableClassVariables(unittest.TestCase):
     """
 
     def setUp(self):
+        """Gather all the `element` classes into `self.elements`"""
         self.base = pymm.Elements.BaseElement
-        #list of all elements
+        # List of the element classes
         self.elements = [self.base, pymm.MindMap]
-        # iterate module, find classes
-        for val in vars(pymm.Elements).values():
-            if type(val) == type(self.base) and isinstance(val(), self.base):
-                self.elements.append(val)
+
+        def is_element_cls(obj):
+            """Checks that x is an object representing a class which inherits
+            from BaseElement."""
+            return inspect.isclass(obj) and isinstance(obj(), self.base)
+
+        for _, cls in inspect.getmembers(pymm.Elements, is_element_cls):
+            self.elements.append(cls)
 
     def test_for_unique_mut_vars(self, filt=None):
         """ searches for mutable variables within an Element, and verifies it
@@ -53,13 +60,13 @@ class TestMutableClassVariables(unittest.TestCase):
             # optional filter to search only for known attributes
             if filt:
                 mutables = [m for m in mutables if m in filt]
-            elemObj = elem_class()
+            element = elem_class()
             # check if vars have same memory address
             for key in mutables:
-                if id(getattr(elemObj, key)) == id(getattr(elem_class, key)):
+                if id(getattr(element, key)) == id(getattr(elem_class, key)):
                     self.fail(str(elem_class) + ' does not copy ' + key)
 
-    def test_for_specific_nonduplicate_mutable_variables(self):
+    def test_specific_nonduplicates(self):
         """ test that children, attrib, _descriptors, and specs are all copied
         to a new list/dict instance in every element when instantiated as an
         instance. This, for example, tests that an instance of MindMap would
@@ -74,11 +81,12 @@ class TestIfRichContentFixedYet(unittest.TestCase):
     """ for now I expect this to fail. idk what to do about it """
 
     @unittest.expectedFailure
-    def test_richcontent_converts_and_writes_to_file(self):
-        rc = mme.RichContent()
-        mm = pymm.MindMap()
-        mm[0].append(rc)
-        mm.write('richcontent_test.mm')
+    def test_convert_and_write(self):
+        """Test that a RichContent object will convert and write."""
+        rich_content = mme.RichContent()
+        mind_map = pymm.MindMap()
+        mind_map[0].append(rich_content)
+        mind_map.write('richcontent_test.mm')
 
 
 class TestTypeVariants(unittest.TestCase):
@@ -91,31 +99,32 @@ class TestTypeVariants(unittest.TestCase):
         self.variants = [mme.Hook,
                          mme.EmbeddedImage, mme.MapConfig, mme.Equation,
                          mme.AutomaticEdgeColor]
-        self.mm = MindMap()
-        root = self.mm[0]
+        self.mind_map = MindMap()
+        root = self.mind_map[0]
         # clear out children of root
         root[:] = []
         for variant in self.variants:
             # add a child variant element type
             root.append(variant())
         self.filename = uuid4().hex + '.mm'
-        # need to remember to erase file later...
-        self.mm.write(self.filename)
-        self.mm2 = pymm.read(self.filename)
+
+        self.mind_map.write(self.filename)
+        self.second_mind_map = pymm.read(self.filename)
 
     def tearDown(self):
-        '''Clean up the previously created temp files.'''
+        """Clean up the previously created temp files."""
         os.remove(self.filename)
 
     def test_for_variants(self):
-        """ check that each of the variants is a child in root node """
-        root = self.mm2[0]
+        """Check that the root contains at least one child for each variant
+        element type."""
+        root = self.second_mind_map[0]
         variants = self.variants.copy()
         for variant in variants:
             for child in root[:]:
                 if isinstance(child, variant):
                     break
-            # we only reach else: if no child matched the given variant
+            # we only reach `else` if no child matched the given variant
             else:
                 self.fail('no child of type: ' + str(variant))
             # remove child after it matches a variant
@@ -129,20 +138,22 @@ class TestReadWriteExample(unittest.TestCase):
         pass
 
     def test_read_file(self):
+        """Test the reading and writing of a mind map."""
         # Since this test could be run outside of it's directory, derive the
         # path to the doc file in a more portable way.
         this_path = os.path.dirname(os.path.realpath(__file__))
         mm_path = os.path.join(this_path, '../docs/input.mm')
-        mm = pymm.read(mm_path)
-        self.assertTrue(mm)
-        self.assertTrue(mm.getroot())
-        mm.write('input_2.mm')
+        mind_map = pymm.read(mm_path)
+        self.assertTrue(mind_map)
+        self.assertTrue(mind_map.getroot())
+        mind_map.write('input_2.mm')
         os.remove('input_2.mm')
 
     def test_write_file(self):
-        mm = MindMap()
+        """Test the writing of a mind map."""
+        mind_map = MindMap()
         # just test that no errors are thrown
-        mm.write('write_test.mm')
+        mind_map.write('write_test.mm')
         os.remove('write_test.mm')
 
 
@@ -152,11 +163,13 @@ class TestNativeChildIndexing(unittest.TestCase):
     """
 
     def setUp(self):
+        """Create generic objects for use in tests."""
         self.element = mme.BaseElement()
         self.node = mme.Node()
         self.node2 = mme.Node()
 
     def test_append_and_index(self):
+        """Test successful appending of node to element."""
         elem = self.element
         node = self.node
         elem.append(node)
@@ -164,6 +177,7 @@ class TestNativeChildIndexing(unittest.TestCase):
         self.assertTrue(node == elem[0])
 
     def test_slicing(self):
+        """Test proper slicing behavior of element."""
         self.element.append(self.node)
         self.element.append(self.node2)
         nodes = self.element[0:2]
@@ -175,6 +189,7 @@ class TestNativeChildIndexing(unittest.TestCase):
         self.assertTrue(self.node2 not in nodes)
 
     def test_remove_and_index(self):
+        """Test removal of nodes from element."""
         elem = self.element
         node = self.node
         node2 = self.node2
@@ -188,6 +203,8 @@ class TestNativeChildIndexing(unittest.TestCase):
         self.assertFalse(elem[:])
 
     def test_remove_error(self):
+        """Ensure proper error handling for erroneous removal of node from
+        element."""
         self.assertRaises(ValueError, self.element.remove, self.node)
         self.element.append(self.node)
         self.assertRaises(ValueError, self.element.remove, self.node2)
@@ -197,6 +214,7 @@ class TestElementAccessor(unittest.TestCase):
     """ Test Element Accessor """
 
     def setUp(self):
+        """Create placeholder objects for tests."""
         self.element = mme.BaseElement()
         self.node = mme.Node()
         self.node2 = mme.Node()
@@ -204,15 +222,17 @@ class TestElementAccessor(unittest.TestCase):
         self.element.nodes = ChildSubset(self.element, tag_regex=r'node')
         self.element.clouds = ChildSubset(self.element, tag_regex=r'cloud')
 
-    def test_add_preconstructed_subset_to_element_class(self):
+    def test_add_preconstructed_subset(self):
+        """Test that BaseElement properly handles addition of subset."""
         mme.BaseElement.nodes = ChildSubset\
                 .class_preconstructor(tag_regex=r'node')
-        e = mme.BaseElement()
-        self.assertTrue(hasattr(e, 'nodes'))
+        elem = mme.BaseElement()
+        self.assertTrue(hasattr(elem, 'nodes'))
         # be sure to remove this class variable
         del mme.BaseElement.nodes
 
     def test_attrib_regex(self):
+        """Test to ensure proper matching of child elements by regex."""
         self.element.colored = ChildSubset(self.element,
                                            attrib_regex={r'COLOR': '.*'})
         colored = self.element.colored
@@ -225,7 +245,8 @@ class TestElementAccessor(unittest.TestCase):
         del node['COLOR']
         self.assertTrue(len(colored) == 0)
 
-    def test_constructor_fails_on_empty_regex(self):
+    def test_constructor_empty_attrib(self):
+        """Test that a child subset cannot be created given an empty regex."""
         elem = self.element
         empties = [[], (), {}, '']
         for empty in empties:
@@ -234,19 +255,22 @@ class TestElementAccessor(unittest.TestCase):
         self.assertRaises(ValueError, ChildSubset,
                           elem, tag_regex='', attrib_regex={})
 
-    def test_constructor_fails_on_wrong_attrib_format(self):
+    def test_constructor_bad_attrib(self):
+        """Test that child subset cannot be created with non-regex attribute."""
         self.assertRaises(ValueError, ChildSubset, self.element,
                           attrib_regex=[2, 3])
         self.assertRaises(ValueError, ChildSubset, self.element,
                           tag_regex=r'node', attrib_regex=('sf', 'as'))
 
-    def test_constructor_fails_on_wrong_tag_format(self):
+    def test_constructor_bad_tag(self):
+        """Test that child subset cannot be created with non-regex tag."""
         self.assertRaises(ValueError, ChildSubset, self.element,
                           tag_regex=['node'])
         self.assertRaises(ValueError, ChildSubset, self.element, tag_regex=5,
                           attrib_regex={'TEXT': '.*'})
 
     def test_alternative_constructor(self):
+        """Test alternative child subset constructor."""
         elem = self.element
         elem.nodes = ChildSubset.class_preconstructor(tag_regex=r'node')
         # why doesn't this work? it should just work w/ elem.nodes(). It works
@@ -254,7 +278,8 @@ class TestElementAccessor(unittest.TestCase):
         elem.nodes = elem.nodes(elem)
         self.assertIsInstance(elem.nodes, ChildSubset)
 
-    def test_node_is_added_to_element_nodes(self):
+    def test_node_added_element_nodes(self):
+        """Test that a node added to elem nodes is properly accessible."""
         elem = self.element
         node = self.node
         elem.nodes.append(node)
@@ -264,6 +289,7 @@ class TestElementAccessor(unittest.TestCase):
         self.assertIn(node, elem.nodes)
 
     def test_node_is_added_using_append(self):
+        """Test node is properly added to element via append method."""
         elem = self.element
         node = self.node
         elem.append(node)
@@ -272,7 +298,8 @@ class TestElementAccessor(unittest.TestCase):
         self.assertIn(node, elem.nodes[:])
         self.assertIn(node, elem.nodes)
 
-    def test_node_is_added_to_element(self):
+    def test_node_added_to_element(self):
+        """Test node is added to element via appending to children."""
         elem = self.element
         node = self.node
         elem.children.append(node)
@@ -281,7 +308,8 @@ class TestElementAccessor(unittest.TestCase):
         self.assertIn(node, elem.nodes[:])
         self.assertIn(node, elem.nodes)
 
-    def test_element_is_not_in_list_of_nodes(self):
+    def test_element_not_in_nodes(self):
+        """Test that an element doesn't show up in a list of nodes."""
         elem = self.element
         node = self.node
         node.append(elem)
@@ -290,29 +318,36 @@ class TestElementAccessor(unittest.TestCase):
         self.assertFalse(elem in node.nodes[:])
         self.assertFalse(elem in node.nodes)
 
-    def test_length_of_nodes_increases_after_adding_node(self):
+    def test_nodes_length_post_addition(self):
+        """Test that the length of nodes of an element increases after adding a
+        node to that element."""
         before = len(self.element.nodes)
         self.element.nodes.append(self.node)
         after = len(self.element.nodes)
         self.assertTrue(before + 1 == after)
 
-    def test_nonmatching_cloud_is_not_in_nodes(self):
+    def test_cloud_not_nodes(self):
+        """Test that adding a cloud to element doesn't expose cloud in nodes."""
         self.element.children.append(self.cloud)
         self.assertTrue(self.cloud not in self.element.nodes)
 
 class TestBaseElement(unittest.TestCase):
+    """Test BaseElement."""
     def setUp(self):
+        """Add generic elements for tests."""
         self.element = mme.BaseElement()
         self.node = mme.Node()
 
-    def test_length_of_element_changes_after_adding_node(self):
+    def test_element_length_post_append(self):
+        """Test length of element increments after adding node."""
         elem = self.element
         before = len(elem)
         elem.children.append(self.node)
         after = len(elem)
         self.assertTrue(before + 1 == after)
 
-    def test_dictionary_returns_correctly_if_attribute_present_or_not(self):
+    def test_dictionary_attribut_return(self):
+        """Test that dict returns correctly if attribute is or isn't present"""
         elem = self.element
         key, value = 'hogwash', 'hogvalue'
         self.assertFalse(key in elem.keys())
@@ -320,29 +355,31 @@ class TestBaseElement(unittest.TestCase):
         elem[key] = value
         self.assertTrue(key in elem.keys())
 
-    def test_set_bad_attribute_warns_user(self):
+    def test_bad_attr_warning(self):
+        """Test that setting a bad attribute raises a user warning."""
         elem = self.element
         self.assertWarns(UserWarning, elem.__setitem__,
                          'invalid attribute should raise warning', None)
 
-    def test_ambiguous_iterate_attributes_raises_error(self):
+    def test_ambiguous_iterate_error(self):
         """ allowing user to iterate over attributes implicitly has proven to
         be a trap; user accidentally iterates """
         self.assertRaises(NotImplementedError, self.element.__iter__)
 
-    def test_ambiguous_implicit_contains_call_raises_error(self):
+    def test_ambiguous_contains_error(self):
         """ ambiguous __contains__ for either attribute or children. Therefore
         raise error to force user to specify which membership he is testing for
         """
         self.assertRaises(NotImplementedError,
                           self.element.__contains__, self.node)
 
-    def test_ambiguous_pop_call_raises_error(self):
+    def test_ambiguous_pop_error(self):
         """ ambiguous pop can refer to attribute or children pop(). Therefore
         raise error to force user to be specific """
         self.assertRaises(NotImplementedError, self.element.pop)
 
-    def test_dictionary_raises_error_for_offspec_attribute_assignment(self):
+    def test_dict_error_offspec_attr(self):
+        """Test dictionary will raise error for offspec attribute assignment"""
         elem = self.element
         elem.specs['string'] = str
         elem.specs['integer'] = int
@@ -352,7 +389,8 @@ class TestBaseElement(unittest.TestCase):
                           'integer', 'this is not an integer')
         self.assertRaises(ValueError, elem.__setitem__, 'one_or_two', 5)
 
-    def test_dictionary_doesnt_error_for_in_spec_attribute_assignment(self):
+    def test_dictionary_inspec_attr(self):
+        """Test that dict won't raise error for inspec attribute assignment."""
         elem = self.element
         elem.specs['string'] = str
         elem.specs['integer'] = int
@@ -366,12 +404,4 @@ class TestBaseElement(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    # comment this out to run the code below
     unittest.main()
-    mm = pymm.MindMap()
-    converter = pymm.Factories.MindMapConverter()
-    tree = converter.revert_mm_element_and_tree(mm.getmap())
-    # getchildren IS DEPRECIATED. Which means that... I need a new way to
-    # traverse children
-    tree.getchildren()
-    print(len(tree))

--- a/test/tests.py
+++ b/test/tests.py
@@ -1,5 +1,6 @@
 import sys
-sys.path.append('../')  # append parent directory so that import finds pymm
+# append parent directory so that import finds pymm
+sys.path.append('../')
 import unittest
 import warnings
 from uuid import uuid4
@@ -27,9 +28,10 @@ class TestMutableClassVariables(unittest.TestCase):
 
     def setUp(self):
         self.base = pymm.Elements.BaseElement
-        self.elements = [self.base, pymm.MindMap]  #list of all elements 
-            # inheriting from BaseElement
-        for v in vars(pymm.Elements).values():  # iterate module, find classes
+        #list of all elements
+        self.elements = [self.base, pymm.MindMap]
+        # iterate module, find classes
+        for v in vars(pymm.Elements).values():
             try:
                 if type(v) == type(self.base) and isinstance(v(), self.base):
                     self.elements.append(v)
@@ -40,21 +42,24 @@ class TestMutableClassVariables(unittest.TestCase):
         """ searches for mutable variables within an Element, and verifies it
         gets copied to a new memory address in each element instance.
         """
-        is_mutable_var = lambda k, v: (isinstance(v, dict) or 
+        is_mutable_var = lambda k, v: (isinstance(v, dict) or
                                 isinstance(v, list)) and not k.endswith('__')
-        baseMutables = [k for k, v in vars(self.base).items() 
+        baseMutables = [k for k, v in vars(self.base).items()
                         if is_mutable_var(k, v)]
         for elemClass in self.elements:
             mutables = [k for k, v in vars(elemClass).items()
                         if is_mutable_var(k, v)]
-            mutables = list(set(baseMutables + mutables))  # unique mutables
-            if filter:  # optional filter to search only for known attributes
+            # unique mutables
+            mutables = list(set(baseMutables + mutables))
+            # optional filter to search only for known attributes
+            if filter:
                 mutables = [m for m in mutables if m in filter]
             elemObj = elemClass()
-            for key in mutables:  # check if vars have same memory address
+            # check if vars have same memory address
+            for key in mutables:
                 if id(getattr(elemObj, key)) == id(getattr(elemClass, key)):
                     self.fail(str(elemClass) + ' does not copy ' + key)
-        
+
     def test_for_specific_nonduplicate_mutable_variables(self):
         """ test that children, attrib, _descriptors, and specs are all copied
         to a new list/dict instance in every element when instantiated as an
@@ -89,11 +94,14 @@ class TestTypeVariants(unittest.TestCase):
                 mme.AutomaticEdgeColor]
         self.mm = MindMap()
         root = self.mm[0]
-        root[:] = []  # clear out children of root
+        # clear out children of root
+        root[:] = []
         for variant in self.variants:
-            root.append(variant())  # add a child variant element type
+            # add a child variant element type
+            root.append(variant())
         self.filename = uuid4().hex + '.mm'
-        self.mm.write(self.filename)  # need to remember to erase file later...
+        # need to remember to erase file later...
+        self.mm.write(self.filename)
         self.mm2 = pymm.read(self.filename)
 
     def tearDown(self):
@@ -108,9 +116,11 @@ class TestTypeVariants(unittest.TestCase):
             for child in root[:]:
                 if isinstance(child, variant):
                     break
-            else:  # we only reach else: if no child matched the given variant
-                self.fail('no child of type: ' + str(variant)) 
-            root.remove(child)  # remove child after it matches a variant
+            # we only reach else: if no child matched the given variant
+            else:
+                self.fail('no child of type: ' + str(variant))
+            # remove child after it matches a variant
+            root.remove(child)
 
 
 class TestReadWriteExample(unittest.TestCase):
@@ -128,7 +138,8 @@ class TestReadWriteExample(unittest.TestCase):
 
     def test_write_file(self):
         mm = MindMap()
-        mm.write('write_test.mm')  # just test that no errors are thrown
+        # just test that no errors are thrown
+        mm.write('write_test.mm')
         os.remove('write_test.mm')
 
 
@@ -155,7 +166,8 @@ class TestNativeChildIndexing(unittest.TestCase):
         nodes = self.element[0:2]
         self.assertTrue(self.node in nodes)
         self.assertTrue(self.node2 in nodes)
-        nodes = self.element[0:2:2]  # should only get node, not node2
+        # should only get node, not node2
+        nodes = self.element[0:2:2]
         self.assertTrue(self.node in nodes)
         self.assertTrue(self.node2 not in nodes)
 
@@ -169,7 +181,8 @@ class TestNativeChildIndexing(unittest.TestCase):
         elem.remove(node)
         self.assertTrue(node2 == elem[0])
         elem.remove(node2)
-        self.assertFalse(elem[:])  # verify elem is child-less
+        # verify elem is child-less
+        self.assertFalse(elem[:])
 
     def test_remove_error(self):
         self.assertRaises(ValueError, self.element.remove, self.node)
@@ -192,7 +205,8 @@ class TestElementAccessor(unittest.TestCase):
         mme.BaseElement.nodes = ChildSubset.class_preconstructor(tag_regex=r'node')
         e = mme.BaseElement()
         self.assertTrue(hasattr(e, 'nodes'))
-        del mme.BaseElement.nodes  # be sure to remove this class variable
+        # be sure to remove this class variable
+        del mme.BaseElement.node
 
     def test_attrib_regex(self):
         self.element.colored = ChildSubset(self.element, attrib_regex={r'COLOR': '.*'})
@@ -229,7 +243,8 @@ class TestElementAccessor(unittest.TestCase):
     def test_alternative_constructor(self):
         elem = self.element
         elem.nodes = ChildSubset.class_preconstructor(tag_regex=r'node')
-        elem.nodes = elem.nodes(elem)  # why doesn't this work? it should just work w/ elem.nodes(). It works ..inside.. the instance, but not outside?
+        # why doesn't this work? it should just work w/ elem.nodes(). It works ..inside.. the instance, but not outside?
+        elem.nodes = elem.nodes(elem)
         self.assertIsInstance(elem.nodes, ChildSubset)
 
     def test_node_is_added_to_element_nodes(self):
@@ -340,10 +355,12 @@ class TestBaseElement(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()  # comment this out to run the code below
+    # comment this out to run the code below
+    unittest.main()
     mm = pymm.MindMap()
     m = mm.getmap()
     converter = pymm.Factories.MindMapConverter()
     tree = converter.revert_mm_element_and_tree(mm.getmap())
-    tree.getchildren()  # getchildren IS DEPRECIATED. Which means that... I need a new way to traverse children
+    # getchildren IS DEPRECIATED. Which means that... I need a new way to traverse children
+    tree.getchildren()
     print(len(tree))

--- a/test/tests.py
+++ b/test/tests.py
@@ -4,6 +4,7 @@ import unittest
 import warnings
 from uuid import uuid4
 import xml
+import os
 try:
     import pymm
     from pymm import Elements as mme
@@ -81,8 +82,9 @@ class TestTypeVariants(unittest.TestCase):
     the same tag. (special attrib values are given that differentiate them)
     """
     def setUp(self):
-        self.variants = [mme.Hook,  # I removed richcontent variants because
-# they do not work correctly when their html is not set. it causes ET to crash
+        # I removed richcontent variants because they do not work correctly
+        # when their html is not set. it causes ET to crash
+        self.variants = [mme.Hook,
                 mme.EmbeddedImage, mme.MapConfig, mme.Equation,
                 mme.AutomaticEdgeColor]
         self.mm = MindMap()
@@ -93,6 +95,10 @@ class TestTypeVariants(unittest.TestCase):
         self.filename = uuid4().hex + '.mm'
         self.mm.write(self.filename)  # need to remember to erase file later...
         self.mm2 = pymm.read(self.filename)
+
+    def tearDown(self):
+        '''Clean up the previously created temp files.'''
+        os.remove(self.filename)
 
     def test_for_variants(self):
         """ check that each of the variants is a child in root node """
@@ -118,10 +124,12 @@ class TestReadWriteExample(unittest.TestCase):
         self.assertTrue(mm)
         self.assertTrue(mm.getroot())
         mm.write('input_2.mm')
+        os.remove('input_2.mm')
 
     def test_write_file(self):
         mm = MindMap()
         mm.write('write_test.mm')  # just test that no errors are thrown
+        os.remove('write_test.mm')
 
 
 class TestNativeChildIndexing(unittest.TestCase):


### PR DESCRIPTION
Cleanup tests to follow PEP8 more closely and reduce Pylint errors as much as possible. List of changes made, in order:
1. Ensure tests cleanup their temporary files
2. Move inline comments to their own line, cleanup trailing whitespace
3. Change name of test file and add `__init__.py` file to allow detection by `nosetests`
4. Cleanup variable names, add missing docstrings, rename overly verbose method names, remove unused imports, delete dead code 
